### PR TITLE
Release 0.2.0.

### DIFF
--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -1,4 +1,4 @@
-// Fermata.ParserCombinators Version 0.1.0
+// Fermata.ParserCombinators Version 0.2.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -378,3 +378,27 @@ let ``end' 3`` () =
     let expected = Error("", State("fsharp", 7))
     let actual = end' (State("fsharp", 7))
     Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``pos 1`` () =
+    let expected = Ok((), State("fsharp", 0))
+    let actual = pos (char' 'f') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``pos 2`` () =
+    let expected = Error("", State("fsharp", 0))
+    let actual = pos (char' 'c') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 1`` () =
+    let expected = Ok((), State("fsharp", 0))
+    let actual = neg (char' 'c') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 2`` () =
+    let expected = Error("", State("fsharp", 0))
+    let actual = neg (char' 'f') (State("fsharp", 0))
+    Assert.Equal(expected, actual)

--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -402,3 +402,15 @@ let ``neg 2`` () =
     let expected = Error("", State("fsharp", 0))
     let actual = neg (char' 'f') (State("fsharp", 0))
     Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``any 1`` () =
+    let expected = Ok('f', State("fsharp", 1))
+    let actual = any (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``any 2`` () =
+    let expected = Error("", State("fsharp", 6))
+    let actual = any (State("fsharp", 6))
+    Assert.Equal(expected, actual)

--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -360,3 +360,21 @@ let ``regex 4`` () =
     let expected = Error("", State("color: #65a2ac;", 7))
     let actual = regex "^#[0-9A-F]{6}" (State("color: #65a2ac;", 7))
     Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``end' 1`` () =
+    let expected = Ok((), State("fsharp", 6))
+    let actual = end' (State("fsharp", 6))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``end' 2`` () =
+    let expected = Error("", State("fsharp", 0))
+    let actual = end' (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``end' 3`` () =
+    let expected = Error("", State("fsharp", 7))
+    let actual = end' (State("fsharp", 7))
+    Assert.Equal(expected, actual)

--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -24,19 +24,19 @@ let ``char' 2`` () =
 
 [<Fact>]
 let ``char' 3`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = char' 'c' (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``char' 4`` () =
-    let expected = Error("", State("fsharp", 6))
+    let expected = Error("Position exceeded input length.", State("fsharp", 6))
     let actual = char' 'x' (State("fsharp", 6))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``char' 5`` () =
-    let expected = Error("", State("", 0))
+    let expected = Error("Input was empty.", State("", 0))
     let actual = char' 'x' (State("", 0))
     Assert.Equal(expected, actual)
 
@@ -48,7 +48,7 @@ let ``<&> 1`` () =
 
 [<Fact>]
 let ``<&> 2`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = (char' 'f' <&> char' '#') (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
@@ -60,7 +60,7 @@ let ``<&> 3`` () =
 
 [<Fact>]
 let ``<&> 4`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = (char' 'f' <&> char' 's' <&> char' 's') (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
@@ -125,7 +125,7 @@ let ``<|> 2`` () =
 
 [<Fact>]
 let ``<|> 3`` () =
-    let expected = Error("", State("sharp", 0))
+    let expected = Error("Parsing failed.", State("sharp", 0))
     let actual = (char' 'f' <|> char' 'c') (State("sharp", 0))
     Assert.Equal(expected, actual)
 
@@ -193,7 +193,7 @@ let ``repeat 2`` () =
 [<Fact>]
 let ``repeat 3`` () =
     let hex = [ '0' .. '9' ] @ [ 'a' .. 'f' ] |> List.map char' |> List.reduce (<|>)
-    let expected = Error("", State("#65a2ac", 0))
+    let expected = Error("Parsing failed.", State("#65a2ac", 0))
     let actual = repeat 6 hex (State("#65a2ac", 0))
     Assert.Equal(expected, actual)
 
@@ -255,7 +255,7 @@ let ``map' 3`` () =
 let ``map' 4`` () =
     let hex = [ '0' .. '9' ] @ [ 'a' .. 'f' ] |> List.map char' |> List.reduce (<|>)
     let f = List.map string >> String.concat "" >> int
-    let expected = Error("", State("#65a2ac", 0))
+    let expected = Error("Parsing failed.", State("#65a2ac", 0))
     let actual = map' f (repeat 6 hex) (State("#65a2ac", 0))
     Assert.Equal(expected, actual)
 
@@ -288,10 +288,10 @@ let ``bind 2`` () =
 
     let binder x =
         match x with
-        | [] -> Error ""
+        | [] -> Error "Parsing failed."
         | _ -> x |> List.map string |> String.concat "" |> int |> Ok
 
-    let expected = Error("", State("#65a2ac", 0))
+    let expected = Error("Parsing failed.", State("#65a2ac", 0))
     let actual = bind binder (many digit) (State("#65a2ac", 0))
     Assert.Equal(expected, actual)
 
@@ -315,25 +315,25 @@ let ``string' 3`` () =
 
 [<Fact>]
 let ``string' 4`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = string' "csharp" (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``string' 5`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Argument was invalid.", State("fsharp", 0))
     let actual = string' "" (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``string' 6`` () =
-    let expected = Error("", State("", 0))
+    let expected = Error("Input was empty.", State("", 0))
     let actual = string' "fsharp" (State("", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``string' 7`` () =
-    let expected = Error("", State("", 0))
+    let expected = Error("Input was empty.", State("", 0))
     let actual = string' "" (State("", 0))
     Assert.Equal(expected, actual)
 
@@ -357,7 +357,7 @@ let ``regex 3`` () =
 
 [<Fact>]
 let ``regex 4`` () =
-    let expected = Error("", State("color: #65a2ac;", 7))
+    let expected = Error("Parsing failed.", State("color: #65a2ac;", 7))
     let actual = regex "^#[0-9A-F]{6}" (State("color: #65a2ac;", 7))
     Assert.Equal(expected, actual)
 
@@ -369,13 +369,13 @@ let ``end' 1`` () =
 
 [<Fact>]
 let ``end' 2`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = end' (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``end' 3`` () =
-    let expected = Error("", State("fsharp", 7))
+    let expected = Error("Position exceeded input length.", State("fsharp", 7))
     let actual = end' (State("fsharp", 7))
     Assert.Equal(expected, actual)
 
@@ -387,7 +387,7 @@ let ``pos 1`` () =
 
 [<Fact>]
 let ``pos 2`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = pos (char' 'c') (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
@@ -399,7 +399,7 @@ let ``neg 1`` () =
 
 [<Fact>]
 let ``neg 2`` () =
-    let expected = Error("", State("fsharp", 0))
+    let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = neg (char' 'f') (State("fsharp", 0))
     Assert.Equal(expected, actual)
 
@@ -411,6 +411,6 @@ let ``any 1`` () =
 
 [<Fact>]
 let ``any 2`` () =
-    let expected = Error("", State("fsharp", 6))
+    let expected = Error("Position exceeded input length.", State("fsharp", 6))
     let actual = any (State("fsharp", 6))
     Assert.Equal(expected, actual)

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -134,3 +134,29 @@ module Parsers =
             if p > len then Error("", State(x, p))
             else if p = len then Ok((), State(x, p))
             else Error("", State(x, p))
+
+    let pos (parser: Parser<'T>) : Parser<unit> =
+        fun (State(x, p)) ->
+            let len = String.length x
+
+            if len = 0 then
+                Error("", State(x, p))
+            else if p >= len then
+                Error("", State(x, p))
+            else
+                match parser (State(x, p)) with
+                | Ok _ -> Ok((), State(x, p))
+                | Error _ -> Error("", State(x, p))
+
+    let neg (parser: Parser<'T>) : Parser<unit> =
+        fun (State(x, p)) ->
+            let len = String.length x
+
+            if len = 0 then
+                Error("", State(x, p))
+            else if p >= len then
+                Error("", State(x, p))
+            else
+                match parser (State(x, p)) with
+                | Ok _ -> Error("", State(x, p))
+                | Error _ -> Ok((), State(x, p))

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -1,4 +1,4 @@
-﻿// Fermata.ParserCombinators Version 0.1.0
+﻿// Fermata.ParserCombinators Version 0.2.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -160,3 +160,11 @@ module Parsers =
                 match parser (State(x, p)) with
                 | Ok _ -> Error("", State(x, p))
                 | Error _ -> Ok((), State(x, p))
+
+    let any: Parser<char> =
+        fun (State(x, p)) ->
+            let len = String.length x
+
+            if len = 0 then Error("", State(x, p))
+            else if p >= len then Error("", State(x, p))
+            else Ok(x.[p], State(x, p + 1))

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -10,14 +10,19 @@ module Parsers =
     type State = State of string * int
     type Parser<'T> = State -> Result<'T * State, string * State>
 
+    let errorsEmpty = "Input was empty."
+    let errorsExceeded = "Position exceeded input length."
+    let errorsFailed = "Parsing failed."
+    let errorsInvalid = "Argument was invalid."
+
     let char' (c: char) : Parser<char> =
         fun (State(x, p)) ->
             let len = String.length x
 
-            if len = 0 then Error("", State(x, p))
-            else if p >= len then Error("", State(x, p))
+            if len = 0 then Error(errorsEmpty, State(x, p))
+            else if p >= len then Error(errorsExceeded, State(x, p))
             else if x.[p] = c then Ok(c, State(x, p + 1))
-            else Error("", State(x, p))
+            else Error(errorsFailed, State(x, p))
 
     let (<&>) (parser1: Parser<'T>) (parser2: Parser<'U>) : Parser<'T * 'U> =
         fun (state: State) ->
@@ -100,71 +105,71 @@ module Parsers =
             let xLen = String.length x
             let sLen = String.length s
 
-            if sLen = 0 then
-                Error("", State(x, p))
-            else if xLen = 0 then
-                Error("", State(x, p))
+            if xLen = 0 then
+                Error(errorsEmpty, State(x, p))
             else if p >= xLen then
-                Error("", State(x, p))
+                Error(errorsExceeded, State(x, p))
+            else if sLen = 0 then
+                Error(errorsInvalid, State(x, p))
             else if x.[p .. p + sLen - 1] = s then
                 Ok(s, State(x, p + sLen))
             else
-                Error("", State(x, p))
+                Error("Parsing failed.", State(x, p))
 
     let regex (pattern: string) : Parser<string> =
         fun (State(x, p)) ->
             let len = String.length x
 
             if len = 0 then
-                Error("", State(x, p))
+                Error(errorsEmpty, State(x, p))
             else if p >= len then
-                Error("", State(x, p))
+                Error(errorsExceeded, State(x, p))
             else
                 let m = System.Text.RegularExpressions.Regex.Match(x.[p..], pattern)
 
                 if m.Success then
                     Ok(m.Value, State(x, p + m.Length))
                 else
-                    Error("", State(x, p))
+                    Error("Parsing failed.", State(x, p))
 
     let end': Parser<unit> =
         fun (State(x, p)) ->
             let len = String.length x
 
-            if p > len then Error("", State(x, p))
+            if p > len then Error(errorsExceeded, State(x, p))
             else if p = len then Ok((), State(x, p))
-            else Error("", State(x, p))
+            else Error("Parsing failed.", State(x, p))
 
     let pos (parser: Parser<'T>) : Parser<unit> =
         fun (State(x, p)) ->
             let len = String.length x
 
             if len = 0 then
-                Error("", State(x, p))
+                Error(errorsEmpty, State(x, p))
             else if p >= len then
-                Error("", State(x, p))
+                Error(errorsExceeded, State(x, p))
             else
                 match parser (State(x, p)) with
                 | Ok _ -> Ok((), State(x, p))
-                | Error _ -> Error("", State(x, p))
+                | Error _ -> Error("Parsing failed.", State(x, p))
 
     let neg (parser: Parser<'T>) : Parser<unit> =
         fun (State(x, p)) ->
             let len = String.length x
 
             if len = 0 then
-                Error("", State(x, p))
+                Error(errorsEmpty, State(x, p))
             else if p >= len then
-                Error("", State(x, p))
+                Error(errorsExceeded, State(x, p))
             else
                 match parser (State(x, p)) with
-                | Ok _ -> Error("", State(x, p))
+                | Ok _ -> Error("Parsing failed.", State(x, p))
                 | Error _ -> Ok((), State(x, p))
 
     let any: Parser<char> =
         fun (State(x, p)) ->
             let len = String.length x
 
-            if len = 0 then Error("", State(x, p))
-            else if p >= len then Error("", State(x, p))
+            if len = 0 then Error(errorsEmpty, State(x, p))
+            else if p >= len then Error(errorsExceeded, State(x, p))
             else Ok(x.[p], State(x, p + 1))

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -126,3 +126,11 @@ module Parsers =
                     Ok(m.Value, State(x, p + m.Length))
                 else
                     Error("", State(x, p))
+
+    let end': Parser<unit> =
+        fun (State(x, p)) ->
+            let len = String.length x
+
+            if p > len then Error("", State(x, p))
+            else if p = len then Ok((), State(x, p))
+            else Error("", State(x, p))

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -474,9 +474,37 @@ module Parsers =
     /// <summary>Returns a new parser that takes a <c>State</c> and returns <c>Ok(unit, State)</c> if parsing succeeded, otherwise <c>Error</c>.</summary>
     /// <param name="parser">The input parser.</param>
     /// <returns>The result parser.</returns>
+    ///
+    /// <example id="pos-1">
+    /// <code lang="fsharp">
+    /// pos (char' 'f') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Ok((), State("fsharp", 0))</c>
+    /// </example>
+    ///
+    /// <example id="pos-2">
+    /// <code lang="fsharp">
+    /// pos (char' 'c') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Error("", State("fsharp", 0))</c>
+    /// </example>
     val pos: parser: Parser<'T> -> Parser<unit>
 
     /// <summary>Returns a new parser that takes a <c>State</c> and returns <c>Ok(unit, State)</c> if parsing failed, otherwise <c>Error</c>.</summary>
     /// <param name="parser">The input parser.</param>
     /// <returns>The result parser.</returns>
+    ///
+    /// <example id="neg-1">
+    /// <code lang="fsharp">
+    /// neg (char' 'c') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Ok((), State("fsharp", 0))</c>
+    /// </example>
+    ///
+    /// <example id="neg-2">
+    /// <code lang="fsharp">
+    /// neg (char' 'f') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Error("", State("fsharp", 0))</c>
+    /// </example>
     val neg: parser: Parser<'T> -> Parser<unit>

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -1,4 +1,4 @@
-// Fermata.ParserCombinators Version 0.1.0
+// Fermata.ParserCombinators Version 0.2.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -445,3 +445,7 @@ module Parsers =
     /// Evaluates to <c>Error("", State("color: #65a2ac;", 7))</c>
     /// </example>
     val regex: pattern: string -> Parser<string>
+
+    /// <summary>Returns <c>Ok(unit, State)</c> if the position in <c>State</c> is at the end of the input, otherwise <c>Error</c>.</summary>
+    /// <returns>The result state.</returns>
+    val end': Parser<unit>

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -448,4 +448,25 @@ module Parsers =
 
     /// <summary>Returns <c>Ok(unit, State)</c> if the position in <c>State</c> is at the end of the input, otherwise <c>Error</c>.</summary>
     /// <returns>The result state.</returns>
+    ///
+    /// <example id="end'-1">
+    /// <code lang="fsharp">
+    /// end' (State("fsharp", 6))
+    /// </code>
+    /// Evaluates to <c>Ok((), State("fsharp", 6))</c>
+    /// </example>
+    ///
+    /// <example id="end'-2">
+    /// <code lang="fsharp">
+    /// end' (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Error("", State("fsharp", 0))</c>
+    /// </example>
+    ///
+    /// <example id="end'-3">
+    /// <code lang="fsharp">
+    /// end' (State("fsharp", 7))
+    /// </code>
+    /// Evaluates to <c>Error("", State("fsharp", 7))</c>
+    /// </example>
     val end': Parser<unit>

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -508,3 +508,21 @@ module Parsers =
     /// Evaluates to <c>Error("", State("fsharp", 0))</c>
     /// </example>
     val neg: parser: Parser<'T> -> Parser<unit>
+
+    /// <summary>Takes a <c>State</s> then returns <c>Ok</c> if the input string in the state has an unread character, otherwise <c>Error</c>.</summary>
+    /// <returns>The result state.</returns>
+    ///
+    /// <example id="any-1">
+    /// <code lang="fsharp">
+    /// any (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Ok('f', State("fsharp", 1))</c>
+    /// </example>
+    ///
+    /// <example id="any-2">
+    /// <code lang="fsharp">
+    /// any (State("fsharp", 6))
+    /// </code>
+    /// Evaluates to <c>Error("", State("fsharp", 6))</c>
+    /// </example>
+    val any: Parser<char>

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -470,3 +470,13 @@ module Parsers =
     /// Evaluates to <c>Error("", State("fsharp", 7))</c>
     /// </example>
     val end': Parser<unit>
+
+    /// <summary>Returns a new parser that takes a <c>State</c> and returns <c>Ok(unit, State)</c> if parsing succeeded, otherwise <c>Error</c>.</summary>
+    /// <param name="parser">The input parser.</param>
+    /// <returns>The result parser.</returns>
+    val pos: parser: Parser<'T> -> Parser<unit>
+
+    /// <summary>Returns a new parser that takes a <c>State</c> and returns <c>Ok(unit, State)</c> if parsing failed, otherwise <c>Error</c>.</summary>
+    /// <param name="parser">The input parser.</param>
+    /// <returns>The result parser.</returns>
+    val neg: parser: Parser<'T> -> Parser<unit>

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsproj
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Fermata.ParserCombinators</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>taidalog</Authors>
     <Company />
     <Description>F# library for operations related to parser combinators. Compatible with Fable.</Description>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 F# library for operations related to parser combinators. Compatible with Fable.
 
-Version 0.1.0
+Version 0.2.0
 
 ## Features
 
@@ -28,13 +28,13 @@ For more information, see the signature file (`.fsi`).
 .NET CLI,
 
 ```
-dotnet add package Fermata.ParserCombinators --version 0.1.0
+dotnet add package Fermata.ParserCombinators --version 0.2.0
 ```
 
 F# Intaractive,
 
 ```
-#r "nuget: Fermata.ParserCombinators, 0.1.0"
+#r "nuget: Fermata.ParserCombinators, 0.2.0"
 ```
 
 For more information, please see [Fermata.ParserCombinators on NuGet Gallery](https://www.nuget.org/packages/Fermata.ParserCombinators).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ For more information, please see [Fermata.ParserCombinators on NuGet Gallery](ht
 
 ## Breaking Changes
 
+### 0.2.0
+
+- Changed `Error` value returned by `Parser<'T>` to hold error information, instead of an empty string.
+
 ## Links
 
 - [Repository on GitHub](https://github.com/taidalog/Fermata.ParserCombinators)


### PR DESCRIPTION
## Summary

- Added new parsers such as `end'`, `pos`, `neg` and `any`.
- Changed `Error` value returned by `Parser<'T>` to hold error information, instead of an empty string.

## Breaking Changes

- Changed `Error` value returned by `Parser<'T>` to hold error information, instead of an empty string.
