### PR TITLE
Release 0.3.0.

### DIFF
--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -1,4 +1,4 @@
-// Fermata.ParserCombinators Version 0.2.0
+// Fermata.ParserCombinators Version 0.3.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators.Tests/Tests.fs
+++ b/Fermata.ParserCombinators.Tests/Tests.fs
@@ -392,6 +392,30 @@ let ``pos 2`` () =
     Assert.Equal(expected, actual)
 
 [<Fact>]
+let ``pos 3`` () =
+    let expected = Ok(("fsharp", ()), State("fsharp", 6))
+    let actual = (string' "fsharp" <&> pos end') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``pos 4`` () =
+    let expected = Ok("fsharp", State("fsharp", 6))
+    let actual = (string' "fsharp" <+&> pos end') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``pos 5`` () =
+    let expected = Error("Parsing failed.", State("fsharp!", 0))
+    let actual = (string' "fsharp" <&> pos end') (State("fsharp!", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``pos 6`` () =
+    let expected = Ok((), State("", 0))
+    let actual = pos end' (State("", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
 let ``neg 1`` () =
     let expected = Ok((), State("fsharp", 0))
     let actual = neg (char' 'c') (State("fsharp", 0))
@@ -401,6 +425,30 @@ let ``neg 1`` () =
 let ``neg 2`` () =
     let expected = Error("Parsing failed.", State("fsharp", 0))
     let actual = neg (char' 'f') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 3`` () =
+    let expected = Ok(("fsharp", ()), State("fsharp!", 6))
+    let actual = (string' "fsharp" <&> neg end') (State("fsharp!", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 4`` () =
+    let expected = Ok("fsharp", State("fsharp!", 6))
+    let actual = (string' "fsharp" <+&> neg end') (State("fsharp!", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 5`` () =
+    let expected = Error("Parsing failed.", State("fsharp", 0))
+    let actual = (string' "fsharp" <+&> neg end') (State("fsharp", 0))
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``neg 6`` () =
+    let expected = Error("Parsing failed.", State("", 0))
+    let actual = neg end' (State("", 0))
     Assert.Equal(expected, actual)
 
 [<Fact>]

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -141,30 +141,16 @@ module Parsers =
             else Error("Parsing failed.", State(x, p))
 
     let pos (parser: Parser<'T>) : Parser<unit> =
-        fun (State(x, p)) ->
-            let len = String.length x
-
-            if len = 0 then
-                Error(errorsEmpty, State(x, p))
-            else if p >= len then
-                Error(errorsExceeded, State(x, p))
-            else
-                match parser (State(x, p)) with
-                | Ok _ -> Ok((), State(x, p))
-                | Error _ -> Error("Parsing failed.", State(x, p))
+        fun state ->
+            match parser state with
+            | Ok _ -> Ok((), state)
+            | Error _ -> Error("Parsing failed.", state)
 
     let neg (parser: Parser<'T>) : Parser<unit> =
-        fun (State(x, p)) ->
-            let len = String.length x
-
-            if len = 0 then
-                Error(errorsEmpty, State(x, p))
-            else if p >= len then
-                Error(errorsExceeded, State(x, p))
-            else
-                match parser (State(x, p)) with
-                | Ok _ -> Error("Parsing failed.", State(x, p))
-                | Error _ -> Ok((), State(x, p))
+        fun state ->
+            match parser state with
+            | Ok _ -> Error("Parsing failed.", state)
+            | Error _ -> Ok((), state)
 
     let any: Parser<char> =
         fun (State(x, p)) ->

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fs
@@ -1,4 +1,4 @@
-﻿// Fermata.ParserCombinators Version 0.2.0
+﻿// Fermata.ParserCombinators Version 0.3.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -488,6 +488,34 @@ module Parsers =
     /// </code>
     /// Evaluates to <c>Error("", State("fsharp", 0))</c>
     /// </example>
+    ///
+    /// <example id="pos-3">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <&> pos end') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Ok(("fsharp", ()), State("fsharp", 6))</c>
+    /// </example>
+    ///
+    /// <example id="pos-4">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <+&> pos end') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Ok("fsharp", State("fsharp", 6))</c>
+    /// </example>
+    ///
+    /// <example id="pos-5">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <&> pos end') (State("fsharp!", 0))
+    /// </code>
+    /// Evaluates to <c>Error("Parsing failed.", State("fsharp!", 0))</c>
+    /// </example>
+    ///
+    /// <example id="pos-6">
+    /// <code lang="fsharp">
+    /// pos end' (State("", 0))
+    /// </code>
+    /// Evaluates to <c>Ok((), State("", 0))</c>
+    /// </example>
     val pos: parser: Parser<'T> -> Parser<unit>
 
     /// <summary>Returns a new parser that takes a <c>State</c> and returns <c>Ok(unit, State)</c> if parsing failed, otherwise <c>Error</c>.</summary>
@@ -506,6 +534,34 @@ module Parsers =
     /// neg (char' 'f') (State("fsharp", 0))
     /// </code>
     /// Evaluates to <c>Error("", State("fsharp", 0))</c>
+    /// </example>
+    ///
+    /// <example id="neg-3">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <&> neg end') (State("fsharp!", 0))
+    /// </code>
+    /// Evaluates to <c>Ok(("fsharp", ()), State("fsharp!", 6))</c>
+    /// </example>
+    ///
+    /// <example id="neg-4">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <+&> neg end') (State("fsharp!", 0))
+    /// </code>
+    /// Evaluates to <c>Ok("fsharp", State("fsharp!", 6))</c>
+    /// </example>
+    ///
+    /// <example id="neg-5">
+    /// <code lang="fsharp">
+    /// (string' "fsharp" <+&> neg end') (State("fsharp", 0))
+    /// </code>
+    /// Evaluates to <c>Error("Parsing failed.", State("fsharp", 0))</c>
+    /// </example>
+    ///
+    /// <example id="neg-6">
+    /// <code lang="fsharp">
+    /// neg end' (State("", 0))
+    /// </code>
+    /// Evaluates to <c>Error("Parsing failed.", State("", 0))</c>
     /// </example>
     val neg: parser: Parser<'T> -> Parser<unit>
 

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsi
@@ -1,4 +1,4 @@
-// Fermata.ParserCombinators Version 0.2.0
+// Fermata.ParserCombinators Version 0.3.0
 // https://github.com/taidalog/Fermata.ParserCombinators
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.ParserCombinators/Fermata.ParserCombinators.fsproj
+++ b/Fermata.ParserCombinators/Fermata.ParserCombinators.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Fermata.ParserCombinators</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>taidalog</Authors>
     <Company />
     <Description>F# library for operations related to parser combinators. Compatible with Fable.</Description>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 F# library for operations related to parser combinators. Compatible with Fable.
 
-Version 0.2.0
+Version 0.3.0
 
 ## Features
 
@@ -28,13 +28,13 @@ For more information, see the signature file (`.fsi`).
 .NET CLI,
 
 ```
-dotnet add package Fermata.ParserCombinators --version 0.2.0
+dotnet add package Fermata.ParserCombinators --version 0.3.0
 ```
 
 F# Intaractive,
 
 ```
-#r "nuget: Fermata.ParserCombinators, 0.2.0"
+#r "nuget: Fermata.ParserCombinators, 0.3.0"
 ```
 
 For more information, please see [Fermata.ParserCombinators on NuGet Gallery](https://www.nuget.org/packages/Fermata.ParserCombinators).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ For more information, please see [Fermata.ParserCombinators on NuGet Gallery](ht
 
 - Changed `Error` value returned by `Parser<'T>` to hold error information, instead of an empty string.
 
+### 0.3.0
+
+- Removed validation from `pos` and `neg` parsers so that they can work with `end'` parser.
+
 ## Links
 
 - [Repository on GitHub](https://github.com/taidalog/Fermata.ParserCombinators)


### PR DESCRIPTION
## Summary

- Removed validation from `pos` and `neg` parsers so that they can work with `end'` parser.
